### PR TITLE
Add redirects for game pages

### DIFF
--- a/src/SquareGrid.Common/Services/Storage/RedirectBlobManager.cs
+++ b/src/SquareGrid.Common/Services/Storage/RedirectBlobManager.cs
@@ -14,12 +14,13 @@ public class RedirectBlobManager
 
     public async Task Upload(RedirectModel model)
     {
-        var blobContent = Layouts.Redirect.Replace("url", model.Url);
-        blobContent = blobContent.Replace("title", model.Title);
-        blobContent = blobContent.Replace("description", model.Description);
-        blobContent = blobContent.Replace("image", model.Image);
+        var blobContent = Layouts.Redirect.Replace("{{url}}", model.Url);
+        blobContent = blobContent.Replace("{{title}}", model.Title);
+        blobContent = blobContent.Replace("{{description}}", model.Description);
+        blobContent = blobContent.Replace("{{image}}", model.Image);
 
-        var blobClient = containerClient.GetBlobClient(model.FriendlyUrl.ToLower());
+        var path = $"{model.GroupName.GenerateSlug()}/{model.CardName.GenerateSlug()}/index.html";
+        var blobClient = containerClient.GetBlobClient(path.ToLower());
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(blobContent));
         await blobClient.UploadAsync(stream, new BlobHttpHeaders { ContentType = "text/html" });
     }
@@ -31,7 +32,7 @@ public class RedirectModel
     public required string Title { get; set; }
     public required string Description { get; set; }
     public required string Image { get; set; }
-    public required string FriendlyUrl { get; set; }
-    public required string Domain { get; set; }
-    public string FullUrl => string.Join("/", new[] { Domain, FriendlyUrl });
+    public required string GroupName { get; set; }
+    public required string CardName { get; set; }
+    public string FullUrl => string.Join("/", new[] { "https://blobstoragecontainer.com", GroupName.GenerateSlug(), CardName.GenerateSlug(), "index.html" });
 }


### PR DESCRIPTION
Fixes #6

Add functionality to create a static HTML file and redirect to the main website.

* **GameFunctions.cs**
  - Add `SendRedirectMessage` method to send a message to the redirects queue containing the title, description, and image.
  - Update `PostGame` method to call `SendRedirectMessage`.
  - Validate and escape the title, description, and image before sending the message to the redirects queue.

* **RedirectBlobManager.cs**
  - Update `Upload` method to use the group and card name fields to create the path for the static HTML file.
  - Ensure the static HTML file contains JS to redirect to the actual page on the main website.
  - Add `GroupName` and `CardName` properties to `RedirectModel`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ourgameltd/squaregrid.api/issues/6?shareId=XXXX-XXXX-XXXX-XXXX).